### PR TITLE
MINOR: allowing for absolute URLs as images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The default options below show you how the relevant data is being retrieved from
     twitterCard: _ => 'summary_large_image',
     type: $page => ['articles', 'posts', 'blog'].some(folder => $page.regularPath.startsWith('/' + folder)) ? 'article' : 'website',
     url: (_, $site, path) => ($site.themeConfig.domain || '') + path,
-    image: ($page, $site) => $page.frontmatter.image && (($site.themeConfig.domain || '') + $page.frontmatter.image),
+    image: ($page, $site) => $page.frontmatter.image && (($site.themeConfig.domain && !$page.frontmatter.image.startsWith('http') || '') + $page.frontmatter.image),
     publishedAt: $page => $page.frontmatter.date && new Date($page.frontmatter.date),
     modifiedAt: $page => $page.lastUpdated && new Date($page.lastUpdated),
 }
@@ -63,7 +63,7 @@ Finally you can also add your own custom meta headers through the `customMeta` o
             $page, // Page configs provided by Vuepress
 
             // All the computed options from above:
-            siteTitle, title, description, author, tags, 
+            siteTitle, title, description, author, tags,
             twitterCard, type, url, image, publishedAt, modifiedAt,
         } = context
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = (options = {}, context) => {
                 publishedAt: options.publishedAt(...optionArgs),
                 modifiedAt: options.modifiedAt(...optionArgs),
             }
-            
+
             options.defaultMeta(addMeta, metaContext)
             options.customMeta(addMeta, metaContext)
             $page.frontmatter.meta = meta
@@ -51,7 +51,7 @@ const defaultOptions = {
     twitterCard: _ => 'summary_large_image',
     type: $page => ['articles', 'posts', 'blog'].some(folder => $page.regularPath.startsWith('/' + folder)) ? 'article' : 'website',
     url: (_, $site, path) => ($site.themeConfig.domain || '') + path,
-    image: ($page, $site) => $page.frontmatter.image && (($site.themeConfig.domain || '') + $page.frontmatter.image),
+    image: ($page, $site) => $page.frontmatter.image && (($site.themeConfig.domain && !$page.frontmatter.image.startsWith('http') || '') + $page.frontmatter.image),
     publishedAt: $page => $page.frontmatter.date && (new Date($page.frontmatter.date)).toISOString(),
     modifiedAt: $page => $page.lastUpdated && (new Date($page.lastUpdated)).toISOString(),
     customMeta: () => {},


### PR DESCRIPTION
Hello @lorisleiva 

thank you for providing this neat helper! Saves me a tone of time! I've noticed an undesirable behaviour I would suggest to fix:

My site has the domain in the theme set (`$site.themeConfig.domain`) and uses absolute URLs for `image` (e.g. https://api.imageee.com/bold?text=Launching%20in%20five%20minutes%20on%20Owwly&bg_image=https://wheretopost.email/images/owwly/owwly.png). This leads to the domain being prefixed:

![image](https://user-images.githubusercontent.com/8433587/82140942-859b4e00-9843-11ea-9dfd-ce85bf2aa103.png)

You can find the bug in this commit: https://github.com/spekulatius/wheretopost.email/commit/9d5cdc40ef416338ddcb570a276192da1f29fbf5 on my open-sourced website.

The suggested change fixes this by checking if an absolute URL is given. Would be great if you could let me know if this something you would like to merge :)

Peter